### PR TITLE
simplification and cleanup, change p-type

### DIFF
--- a/lang/cs/lang.php
+++ b/lang/cs/lang.php
@@ -3,8 +3,8 @@
  * czech language file
  */
 
-$lang['fig']           = 'Obr. ';
-$lang['figure']        = 'obrázek ';
-$lang['error_imgrefbeforeimgcaption']      = 'imgref tag is placed before the referenced imgcaption tag. This is not allowed';
+$lang['fig']           = 'Obr.';
+$lang['figure']        = 'obrázek';
+$lang['error_imgrefbeforeimgcaption'] = 'imgref tag is placed before the referenced imgcaption tag. This is not allowed';
 
 ?>

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -3,8 +3,8 @@
  * german language file
  */
 
-$lang['fig'] = 'Abb. ';
-$lang['figure'] = 'Abbildung ';
+$lang['fig'] = 'Abb.';
+$lang['figure'] = 'Abbildung';
 $lang['error_imgrefbeforeimgcaption'] = 'imgref tag ist vor dem referenzierten imgcaption Tag. Das ist nicht erlaubt.';
 
 ?>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -3,6 +3,6 @@
  * english language file
  */
 
-$lang['fig']           = 'Fig. ';
+$lang['fig']           = 'Fig.';
 $lang['figure']        = 'figure';
 $lang['error_imgrefbeforeimgcaption']      = 'imgref tag is placed before the referenced imgcaption tag. This is not allowed';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -3,8 +3,8 @@
  * french language file
  */
 
-$lang['fig'] = 'Fig. ';
-$lang['figure'] = 'figure ';
+$lang['fig'] = 'Fig.';
+$lang['figure'] = 'figure';
 $lang['error_imgrefbeforeimgcaption']      = 'imgref tag is placed before the referenced imgcaption tag. This is not allowed';
 
 ?> 

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * dutch language file
+ */
+
+$lang['fig']           = 'Fig.';
+$lang['figure']        = 'figuur';
+$lang['error_imgrefbeforeimgcaption'] = 'imgref tag is voor de imgcaption tag geplaatst waarnaar die verwijst. Dit is niet mogelijk.';

--- a/script.js
+++ b/script.js
@@ -1,48 +1,58 @@
 function checkImages() {
 
-    var divs=document.getElementsByTagName("DIV");
+    jQuery('span.imgcaption').each(function () {
+        var $imgcaption = jQuery(this);
+        var $amedia = $imgcaption.find('a.media');
+        var $img = $imgcaption.find('img');
 
-    for (var i=0;i<divs.length;i++) {
-        if (divs[i].className == "imgcaption" || divs[i].className == "imgcaptionleft" || divs[i].className == "imgcaptionright") {
-
-            var children = divs[i].getElementsByTagName("IMG");
-            // check if there is a link encapsulating the image        
-            var tmpImg = divs[i].childNodes[0].childNodes[0];
-            if (tmpImg === null) {
-                tmpImg = divs[i].childNodes[0];
-            }
-            else {
-                // we have link and we can build the link image
-                var innerElements = divs[i];
-                var iLink = innerElements.childNodes[1].childNodes[2];
-                var iSpan = iLink.childNodes[0];
-                // set the href of the link to the image link
-                iLink.href = innerElements.childNodes[0].href;
-                // show the link image
-                iSpan.style.display="inline";
-            }
-            //var tmpLink = divs[i].childNodes[0];
-            divs[i].style.width=(tmpImg.width + 8)+"px";
+        //copy img url to magnify button
+        if ($amedia[0]) {
+            var link = $amedia.attr('href');
+            $imgcaption.find('span.undercaption a').last()
+                .attr('href', link)//set link
+                .children().show(); //display button
         }
-      }
-  }
- 
- 
-  if(window.toolbar !== undefined){
-    toolbar[toolbar.length] = {"type":"format",
-                             "title":"Adds an ImageCaption tag",
-                             "icon":"../../plugins/imagereference/button.png",
-                             "key":"",
-                             "open":"<imgcaption image1|>",
-                             "close":"</imgcaption>"};
-     toolbar[toolbar.length] = {"type":"format",
-                             "title":"Adds an ImageReference tag",
-                             "icon":"../../plugins/imagereference/refbutton.png",
-                             "key":"",
-                             "open":"<imgref ",
-                             "sample":"image1",
-                             "close":">"};
+
+        //set imgcaption width equal to image
+        var width = $img.width();
+        $imgcaption.width((width + 8) + "px");
+
+        //apply alignment of image to imgcaption
+        if (!($imgcaption.hasClass('left') || $imgcaption.hasClass('right') || $imgcaption.hasClass('center'))) {
+            if ($img.hasClass('medialeft')) {
+                $imgcaption.addClass('left');
+            }
+            else if ($img.hasClass('mediaright')) {
+                $imgcaption.addClass('right');
+            }
+            else if ($img.hasClass('mediacenter')) {
+                $imgcaption.addClass('center');
+            }
+        }
+    });
 }
 
 
-  addInitEvent(function(){checkImages();});
+if (window.toolbar !== undefined) {
+    toolbar[toolbar.length] = {
+        "type": "format",
+        "title": "Adds an ImageCaption tag",
+        "icon": "../../plugins/imagereference/button.png",
+        "key": "",
+        "open": "<imgcaption image1|>",
+        "close": "</imgcaption>"
+    };
+    toolbar[toolbar.length] = {
+        "type": "format",
+        "title": "Adds an ImageReference tag",
+        "icon": "../../plugins/imagereference/refbutton.png",
+        "key": "",
+        "open": "<imgref ",
+        "sample": "image1",
+        "close": ">"
+    };
+}
+
+jQuery(function () {
+    checkImages();
+});

--- a/script.js
+++ b/script.js
@@ -12,6 +12,12 @@ function checkImages() {
                 .attr('href', link)//set link
                 .children().show(); //display button
         }
+        //copy possibly img title when no caption is set
+        var captionparts = $imgcaption.find('span.undercaption').text().split(':', 2);
+        if(!jQuery.trim(captionparts[1])) {
+            var title = $img.attr('title');
+            $imgcaption.find('span.undercaption a').first().before(title);
+        }
 
         //set imgcaption width equal to image
         var width = $img.width();
@@ -28,6 +34,10 @@ function checkImages() {
             else if ($img.hasClass('mediacenter')) {
                 $imgcaption.addClass('center');
             }
+        }
+        //add wrapper to center imgcaption
+        if($imgcaption.hasClass('center')) {
+            $imgcaption.wrap('<span class="imgcaption_centerwrapper"></span>');
         }
     });
 }

--- a/style.css
+++ b/style.css
@@ -27,11 +27,10 @@ span.imgcaption.right {
     margin: 1px;
     float: right;
 }
-span.imgcaption.center {
-    margin: 1px;
+span.imgcaption_centerwrapper {
     display: block;
+    text-align: center;
 }
-
 
 span.imgcaption a img {
     border: 1px solid #ccc;

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@
  */
 
 
-div.imgcaption {
+span.imgcaption {
     border: 1px solid #ccc;
     padding: 3px !important;
     background-color: #f9f9f9;  
@@ -16,49 +16,31 @@ div.imgcaption {
     overflow: hidden;
     margin: 1px auto;
     float: none;
+    display: inline-block;
 }
 
-div.imgcaptionleft {
-    border: 1px solid #ccc;
-    padding: 3px !important;
-    background-color: #f9f9f9;
-    font-size: 94%;
-    text-align: center;
-    width: auto;
-    overflow: hidden;
+span.imgcaption.left {
     margin: 1px;
     float: left;
 }
-
-div.imgcaptionright {
-    border: 1px solid #ccc;
-    padding: 3px !important;
-    background-color: #f9f9f9;
-    font-size: 94%;
-    text-align: center;
-    width: auto;
-    overflow: hidden;
+span.imgcaption.right {
     margin: 1px;
     float: right;
 }
+span.imgcaption.center {
+    margin: 1px;
+    display: block;
+}
 
 
-div.imgcaption a img {
-    border: 1px solid #ccc;
-    background-color:#FFFFFF;
-}
-div.imgcaptionleft a img {
-    border: 1px solid #ccc;
-    background-color:#FFFFFF;
-}
-div.imgcaptionright a img {
+span.imgcaption a img {
     border: 1px solid #ccc;
     background-color:#FFFFFF;
 }
 
 div.dokuwiki .undercaption {
 	 font-size: 95%;
-    
+     display: block;
 }
 
 div.dokuwiki .undercaption a:hover {
@@ -74,13 +56,12 @@ div.dokuwiki .undercaption span {
     display:none;
 }
 
-
-div.imgcaption img.mediaright {
+div.dokuwiki span.imgcaption img.mediaright {
   float: none;
   margin: 0 0 0.5em 0;
 }
 
-div.imgcaption img.medialeft {
+div.dokuwiki span.imgcaption img.medialeft {
   float: none;
   margin: 0 0 0.5em 0;
 }

--- a/syntax/imgcaption.php
+++ b/syntax/imgcaption.php
@@ -4,16 +4,16 @@
  *
  * Syntax: <imgref linkname> - creates a figure link to an image
  *         <imgcaption linkname <orientation> | Image caption> Image/Table</imgcaption>
- * 
+ *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Martin Heinemann <martinheinemann@tudor.lu>
  */
- 
-if (!defined('DOKU_INC')) die();
 
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_LF')) define('DOKU_LF', "\n");
+if(!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
 
 require_once DOKU_PLUGIN.'syntax.php';
 /**
@@ -21,14 +21,12 @@ require_once DOKU_PLUGIN.'syntax.php';
  * need to inherit from this class
  */
 class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
- 	
-	
-	var $_figure_name_array = array("");
-	var $_figure_map = array();
-	
-	
-    function getInfo(){
-        return array( 
+
+    var $_figure_name_array = array("");
+    var $_figure_map = array();
+
+    function getInfo() {
+        return array(
             'author' => 'Martin Heinemann',
             'email'  => 'info@martinheinemann.net',
             'date'   => '2012-08-21',
@@ -37,213 +35,222 @@ class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
             'url'    => 'http://wiki.splitbrain.org/wiki:plugins',
         );
     }
- 
-   
-   function getType(){ return 'protected';}
-    function getAllowedTypes() { return array('container','substition','protected','disabled','formatting','paragraphs'); }
-    function getPType(){ return 'block';}
+
+    function getType() {
+        return 'protected';
+    }
+
+    function getAllowedTypes() {
+        return array('container', 'substition', 'protected', 'disabled', 'formatting', 'paragraphs');
+    }
+
+    function getPType() {
+        return 'block';
+    }
 
     // must return a number lower than returned by native 'code' mode (200)
-    function getSort(){ return 196; }
+    function getSort() {
+        return 196;
+    }
 
     // override default accepts() method to allow nesting 
     // - ie, to get the plugin accepts its own entry syntax
     function accepts($mode) {
-        if ($mode == substr(get_class($this), 7)) return true;
+        if($mode == substr(get_class($this), 7)) return true;
 
         return parent::accepts($mode);
     }
- 
-   /**
-    * Connect lookup pattern to lexer.
-    *
-    * @param $aMode String The desired rendermode.
-    * @return none
-    * @public
-    * @see render()
-    */
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param $aMode String The desired rendermode.
+     * @return none
+     * @public
+     * @see render()
+     */
     function connectTo($mode) {
-        $this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?>(?=.*?</imgcaption.*?>)',$mode,'plugin_imagereference_imgcaption');
-        $this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?\|(?=[^\r\n]*>.*?</imgcaption.*>)',$mode,'plugin_imagereference_imgcaption');
+        $this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?>(?=.*?</imgcaption.*?>)', $mode, 'plugin_imagereference_imgcaption');
+        $this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?\|(?=[^\r\n]*>.*?</imgcaption.*>)', $mode, 'plugin_imagereference_imgcaption');
     }
- 
+
     function postConnect() {
         $this->Lexer->addExitPattern('</imgcaption>', 'plugin_imagereference_imgcaption');
     }
- 	
- 
-    function handle($match, $state, $pos, &$handler){
-    	
-        switch ($state) {
-           case DOKU_LEXER_ENTER : {
-           	$refLabel = trim(substr($match, 11, -1));
-           	$parsedInput = $this->_parseParam($refLabel);
-           	
-           	array_push($this->_figure_name_array, $parsedInput[0]);
-           	
-           	$this->_figure_map[$parsedInput[0]] = "";
-           	
-        	return array('caption_open', $parsedInput);  // image anchor label
-           }
-          case DOKU_LEXER_UNMATCHED : {
-    		$parsed = $this->_parseContent($match);      	
-          	$this->_figure_map[end($this->_figure_name_array)] = $this->_imgend($parsed[0]);
-          	
-        	return array('data', '');
-          }
-           
-          case DOKU_LEXER_EXIT :
-        	return array('caption_close', $this->_figure_map[end($this->_figure_name_array)]);
-          case DOKU_LEXER_MATCHED :
-        	return array('data', "----".$match."------");
+
+    function handle($match, $state, $pos, &$handler) {
+
+        switch($state) {
+            case DOKU_LEXER_ENTER :
+                $refLabel    = trim(substr($match, 11, -1));
+                $parsedInput = $this->_parseParam($refLabel);
+
+                array_push($this->_figure_name_array, $parsedInput[0]);
+
+                $this->_figure_map[$parsedInput[0]] = "";
+
+                return array('caption_open', $parsedInput); // image anchor label
+            case DOKU_LEXER_UNMATCHED :
+                $parsed                                            = $this->_parseContent($match);
+                $this->_figure_map[end($this->_figure_name_array)] = $this->_imgend($parsed[0]);
+
+                return array('data', '');
+            case DOKU_LEXER_EXIT :
+                return array('caption_close', $this->_figure_map[end($this->_figure_name_array)]);
+            case DOKU_LEXER_MATCHED :
+                return array('data', "----".$match."------");
         }
-        
+
         return array();
     }
- 
+
     function render($mode, &$renderer, $indata) {
 
         list($case, $data) = $indata;
-        if($mode == 'xhtml'){
-            switch ($case) {
-               case 'caption_open' :  $renderer->doc .= $this->_imgstart($data); break;
-               case 'caption_close' :  {
-               // -------------------------------------------------------
-               list($name, $number, $caption) = $data;
-               $layout = "<div class=\"undercaption\">".$this->getLang('fig').$number.": 
+        if($mode == 'xhtml') {
+            switch($case) {
+                case 'caption_open' :
+                    $renderer->doc .= $this->_imgstart($data);
+                    break;
+                case 'caption_close' :
+                    // -------------------------------------------------------
+                    list($name, $number, $caption) = $data;
+                    $layout = "<div class=\"undercaption\">".$this->getLang('fig').$number.":
                     <a name=\"".$name."\">".$caption."</a><a href=\" \"><span></span></a>
                     </div></div>";
-               $renderer->doc .= $layout; break;
-               }
+                    $renderer->doc .= $layout;
+                    break;
                 // -------------------------------------------------------	
                 // data is mostly empty!!!
-            case 'data' : $renderer->doc .= $data; break; 
+                case 'data' :
+                    $renderer->doc .= $data;
+                    break;
             }
             // store the image refences as metadata to expose them to the
             // imgref renderer
             $tmp = $renderer->meta['imagreference'];
-            if (!is_null($tmp) && is_array($tmp)) {
+            if(!is_null($tmp) && is_array($tmp)) {
                 $renderer->meta['imagereferences'] = array_merge($tmp, $this->_figure_name_array);
-                
+
             } else {
                 $renderer->meta['imagereferences'] = $this->_figure_name_array;
             }
             return true;
         }
         if($mode == 'latex') {
-        	// -----------------------------------------
-        	switch ($case) {
-               /* case 'imgref' :  {
-	               	$renderer->doc .= "\\ref{".$data."}"; break;
-               } */ 
-               case 'caption_open' :  {
-               		// --------------------------------------
-               		$orientation = "\\centering";
-               		switch($data[1]) {
-               			case 'left'  : $orientation = "\\left";break;
-               			case 'right' : $orientation = "\\right";break;
-               		}
-               		$renderer->doc .= "\\begin{figure}[H!]{".$orientation; break;
-               		// --------------------------------------
-               }
-               case 'caption_close' : {
-               		// -------------------------------------------------------
-               		list($name, $number, $caption) = $data;
-               		$layout = "\\caption{".$caption."}\\label{".$name."}\\end{figure}";
-               		$renderer->doc .= $layout; break;
-               }
+            // -----------------------------------------
+            switch($case) {
+                /* case 'imgref' :  {
+                       $renderer->doc .= "\\ref{".$data."}"; break;
+               } */
+                case 'caption_open' :
+                    // --------------------------------------
+                    $orientation = "\\centering";
+                    switch($data[1]) {
+                        case 'left'  :
+                            $orientation = "\\left";
+                            break;
+                        case 'right' :
+                            $orientation = "\\right";
+                            break;
+                    }
+                    $renderer->doc .= "\\begin{figure}[H!]{".$orientation;
+                    break;
+                    // --------------------------------------
+                case 'caption_close' :
+                    // -------------------------------------------------------
+                    list($name, $number, $caption) = $data;
+                    $layout = "\\caption{".$caption."}\\label{".$name."}\\end{figure}";
+                    $renderer->doc .= $layout;
+                    break;
 
-			   case 'data' :  $renderer->doc .= trim($data); break;
+                case 'data' :
+                    $renderer->doc .= trim($data);
+                    break;
             }
-            
+
             return true;
-        	// -----------------------------------------
+            // -----------------------------------------
         }
-        
-        
+
         return false;
     }
-    
-    
-    
-	function _parseParam($str) {
-      if ( $str == null  || count ( $str ) < 1 ) {
-        return array();
-      }
-      $styles = array();
-	
-      // get the img ref name. Its the first word
-      $parsed = explode(" ", $str, 2);
-      $imgref = $parsed[0];
-      
-      
-      $tokens = preg_split('/\s+/', $parsed[1], 9);                      // limit is defensive
-	      foreach ($tokens as $token) {
-	          // restrict token (class names) characters to prevent any malicious data
-	          if (preg_match('/[^A-Za-z0-9_-]/',$token)) continue;
-	          $styles['class'] = (isset($styles['class']) ? $styles['class'].' ' : '').$token;
-	      }
-		// return imageref name , style
-		// e.G.    image1,left
-      return array($imgref, $styles['class']);
+
+    function _parseParam($str) {
+        if($str == null || count($str) < 1) {
+            return array();
+        }
+        $styles = array();
+
+        // get the img ref name. Its the first word
+        $parsed = explode(" ", $str, 2);
+        $imgref = $parsed[0];
+
+        $tokens = preg_split('/\s+/', $parsed[1], 9); // limit is defensive
+        foreach($tokens as $token) {
+            // restrict token (class names) characters to prevent any malicious data
+            if(preg_match('/[^A-Za-z0-9_-]/', $token)) continue;
+            $styles['class'] = (isset($styles['class']) ? $styles['class'].' ' : '').$token;
+        }
+        // return imageref name , style
+        // e.G.    image1,left
+        return array($imgref, $styles['class']);
     }
-    
-    
+
     function _imgstart($str) {
-    	// ============================================ //
-    	if (!strlen($str)) return array();
-    	
-		$layout = "<div class=\"imgcaption";
-		//$layout = "<div><div class=\"imgcaption";
-		if ($str[1] != "")
-			$layout = $layout.$str[1];
-		$layout = $layout."\">";
-		
-    	return $layout;
-    	// ============================================ //
+        // ============================================ //
+        if(!strlen($str)) return array();
+
+        $layout = "<div class=\"imgcaption";
+        //$layout = "<div><div class=\"imgcaption";
+        if($str[1] != "")
+            $layout = $layout.$str[1];
+        $layout = $layout."\">";
+
+        return $layout;
+        // ============================================ //
     }
-    
-    
+
     /**
-     * 
+     *
      *
      * @param String $str the image caption
      * @return array(imagename, image number, image caption)
      */
     function _imgend($str) {
-    	// ===================================================== //
-    	$figureName = end($this->_figure_name_array);
-    	// get the position of the figure in the array
-		$refNumber = array_search($figureName, $this->_figure_name_array);
-		
-		return array($figureName, $refNumber, $str);
-		
-		$layout = "<div class=\"undercaption\">".$this->getLang('fig').$refNumber.": 
+        // ===================================================== //
+        $figureName = end($this->_figure_name_array);
+        // get the position of the figure in the array
+        $refNumber = array_search($figureName, $this->_figure_name_array);
+
+        return array($figureName, $refNumber, $str);
+
+        $layout = "<div class=\"undercaption\">".$this->getLang('fig').$refNumber.":
 		<a name=\"".end($this->_figure_name_array)."\">".$str."</a></div>";
-		
-		//$layout = "<div id=\"undercaption\">Fig. ".$refNumber.": 
-		//<a name=\"".end($this->_figure_name_array)."\">".$str."</a></div></div></div>";
-		
-		return $layout;
-    	// ===================================================== 
+
+        //$layout = "<div id=\"undercaption\">Fig. ".$refNumber.":
+        //<a name=\"".end($this->_figure_name_array)."\">".$str."</a></div></div></div>";
+
+        return $layout;
+        // =====================================================
     }
+
     /**
      * divides the image caption and the content between the tags
      *
      */
-    
+
     function _parseContent($str) {
-    	// ======================================================
-    	if (!strlen($str)) return "";
-    	// parse for '>' 
-    	$parsed = explode(">", $str, 2);
-    	
-    	return $parsed;
-    	// ======================================================
+        // ======================================================
+        if(!strlen($str)) return "";
+        // parse for '>'
+        $parsed = explode(">", $str, 2);
+
+        return $parsed;
+        // ======================================================
     }
-    
-   
+
 }
- 
+
 //Setup VIM: ex: et ts=4 enc=utf-8 :
 ?>

--- a/syntax/imgcaption.php
+++ b/syntax/imgcaption.php
@@ -59,9 +59,7 @@ class syntax_plugin_imagereference_imgcaption extends DokuWiki_Syntax_Plugin {
      * @see render()
      */
     function connectTo($mode) {
-        /*$this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?>(?=.*?</imgcaption.*?>)', $mode, 'plugin_imagereference_imgcaption');*/
         $this->Lexer->addEntryPattern('<imgcaption.*?>(?=.*?</imgcaption>)', $mode, 'plugin_imagereference_imgcaption');
-        /*$this->Lexer->addEntryPattern('<imgcaption\s[^\r\n\|]*?\|(?=[^\r\n]*>.*?</imgcaption.*>)', $mode, 'plugin_imagereference_imgcaption');*/
     }
 
     function postConnect() {

--- a/syntax/imgref.php
+++ b/syntax/imgref.php
@@ -4,16 +4,16 @@
  *
  * Syntax: <imgref linkname> - creates a figure link to an image
  *         <imgcaption linkname <orientation> | Image caption> Image/Table</imgcaption>
- * 
+ *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Martin Heinemann <info@martinheinemann.net>
  */
- 
-if (!defined('DOKU_INC')) die();
 
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_LF')) define('DOKU_LF', "\n");
+if(!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
 
 require_once DOKU_PLUGIN.'syntax.php';
 /**
@@ -21,14 +21,12 @@ require_once DOKU_PLUGIN.'syntax.php';
  * need to inherit from this class
  */
 class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
- 	
-	
-	var $_figure_name_array = array("");
-	var $_figure_map = array();
-	
-	
-    function getInfo(){
-        return array( 
+
+    var $_figure_name_array = array("");
+    var $_figure_map = array();
+
+    function getInfo() {
+        return array(
             'author' => 'Martin Heinemann',
             'email'  => 'info@martinheinemann.net',
             'date'   => '2012-08-21',
@@ -37,93 +35,106 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
             'url'    => 'http://wiki.splitbrain.org/wiki:plugins',
         );
     }
- 
-   
-   function getType(){ return 'protected';}
-    function getAllowedTypes() { return array('container','substition','protected','disabled','formatting','paragraphs'); }
-    function getPType(){ return 'normal';}
+
+    function getType() {
+        return 'protected';
+    }
+
+    function getAllowedTypes() {
+        return array('container', 'substition', 'protected', 'disabled', 'formatting', 'paragraphs');
+    }
+
+    function getPType() {
+        return 'normal';
+    }
 
     // must return a number lower than returned by native 'code' mode (200)
-    function getSort(){ return 197; }
+    function getSort() {
+        return 197;
+    }
 
     // override default accepts() method to allow nesting 
     // - ie, to get the plugin accepts its own entry syntax
     function accepts($mode) {
-        if ($mode == substr(get_class($this), 7)) return true;
+        if($mode == substr(get_class($this), 7)) return true;
 
         return parent::accepts($mode);
     }
- 
-   /**
-    * Connect lookup pattern to lexer.
-    *
-    * @param $aMode String The desired rendermode.
-    * @return none
-    * @public
-    * @see render()
-    */
+
+    /**
+     * Connect lookup pattern to lexer.
+     *
+     * @param $aMode String The desired rendermode.
+     * @return none
+     * @public
+     * @see render()
+     */
     function connectTo($mode) {
-      $this->Lexer->addSpecialPattern('<imgref\s[^\r\n]*?>',$mode, 'plugin_imagereference_imgref');
+        $this->Lexer->addSpecialPattern('<imgref\s[^\r\n]*?>', $mode, 'plugin_imagereference_imgref');
     }
- 
+
     function postConnect() {
     }
- 	
- 
-    function handle($match, $state, $pos, &$handler){
-    	
-        switch ($state) {
-          case DOKU_LEXER_SPECIAL : {
+
+    function handle($match, $state, $pos, &$handler) {
+
+        switch($state) {
+            case DOKU_LEXER_SPECIAL :
+                {
                 $ref = substr($match, 8, -1);
                 return array('imgref', $ref);
-          }
+                }
         }
-        
+
         return array();
     }
- 
+
     function render($mode, &$renderer, $indata) {
         list($case, $data) = $indata;
-        if($mode == 'xhtml'){
-            switch ($case) {
-               case 'imgref' :  {
+        if($mode == 'xhtml') {
+            switch($case) {
+                case 'imgref' :
                     $_figure_name_array = $renderer->meta['imagereferences'];
-                    if (is_array($_figure_name_array)) {
+                    if(is_array($_figure_name_array)) {
                         $refNumber = array_search($data, $_figure_name_array);
-                        if ($refNumber == null || $refNumber == "")
-                        $refNumber = "##";
+                        if($refNumber == null || $refNumber == "")
+                            $refNumber = "##";
                         $str = "<a href=\"#".$data."\">".$this->getLang('figure').$refNumber." </a>";
-                        $renderer->doc .= $str; break;
+                        $renderer->doc .= $str;
+                        break;
                     } else {
                         $warning = "$data<sup style=\"color:#FF0000;\">".$this->getLang('error_imgrefbeforeimgcaption')."</sup>";
                         $renderer->doc .= $warning;
                     }
-               }
                 // data is mostly empty!!!
-                case 'data' : $renderer->doc .= $data; break; 
+                case 'data' :
+                    $renderer->doc .= $data;
+                    break;
             }
-            
+
             return true;
         }
         if($mode == 'latex') {
-        	// -----------------------------------------
-        	switch ($case) {
-               case 'imgref' :  {
-	               	/* --------------------------------------- */
-	               	$renderer->doc .= "\\ref{".$data."}"; break;
-	               	/* --------------------------------------- */
-               }
+            // -----------------------------------------
+            switch($case) {
+                case 'imgref' :
+                    /* --------------------------------------- */
+                    $renderer->doc .= "\\ref{".$data."}";
+                    break;
+                    /* --------------------------------------- */
 
-			   case 'data' :  $renderer->doc .= trim($data); break;
+                case 'data' :
+                    $renderer->doc .= trim($data);
+                    break;
             }
-            
+
             return true;
-        	// -----------------------------------------
+            // -----------------------------------------
         }
         return false;
     }
-    
+
 }
- 
+
 //Setup VIM: ex: et ts=4 enc=utf-8 :
 ?>

--- a/syntax/imgref.php
+++ b/syntax/imgref.php
@@ -25,17 +25,6 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
     var $_figure_name_array = array("");
     var $_figure_map = array();
 
-    function getInfo() {
-        return array(
-            'author' => 'Martin Heinemann',
-            'email'  => 'info@martinheinemann.net',
-            'date'   => '2012-08-21',
-            'name'   => 'imagereference',
-            'desc'   => 'Create image references like latex is doing with figures',
-            'url'    => 'http://wiki.splitbrain.org/wiki:plugins',
-        );
-    }
-
     function getType() {
         return 'protected';
     }
@@ -80,10 +69,8 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
 
         switch($state) {
             case DOKU_LEXER_SPECIAL :
-                {
                 $ref = substr($match, 8, -1);
                 return array('imgref', $ref);
-                }
         }
 
         return array();
@@ -99,13 +86,15 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
                         $refNumber = array_search($data, $_figure_name_array);
                         if($refNumber == null || $refNumber == "")
                             $refNumber = "##";
-                        $str = "<a href=\"#".$data."\">".$this->getLang('figure').$refNumber." </a>";
+                        $str = "<a href=\"#".$data."\">".$this->getLang('figure')." ".$refNumber." </a>";
                         $renderer->doc .= $str;
-                        break;
+
                     } else {
                         $warning = "$data<sup style=\"color:#FF0000;\">".$this->getLang('error_imgrefbeforeimgcaption')."</sup>";
                         $renderer->doc .= $warning;
                     }
+                    break;
+
                 // data is mostly empty!!!
                 case 'data' :
                     $renderer->doc .= $data;
@@ -115,13 +104,10 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
             return true;
         }
         if($mode == 'latex') {
-            // -----------------------------------------
             switch($case) {
                 case 'imgref' :
-                    /* --------------------------------------- */
                     $renderer->doc .= "\\ref{".$data."}";
                     break;
-                    /* --------------------------------------- */
 
                 case 'data' :
                     $renderer->doc .= trim($data);
@@ -129,7 +115,6 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
             }
 
             return true;
-            // -----------------------------------------
         }
         return false;
     }
@@ -137,4 +122,3 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
 }
 
 //Setup VIM: ex: et ts=4 enc=utf-8 :
-?>

--- a/syntax/imgref.php
+++ b/syntax/imgref.php
@@ -86,18 +86,13 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
                         $refNumber = array_search($data, $_figure_name_array);
                         if($refNumber == null || $refNumber == "")
                             $refNumber = "##";
-                        $str = "<a href=\"#".$data."\">".$this->getLang('figure')." ".$refNumber." </a>";
+                        $str = "<a href=\"#".cleanID($data)."\">".$this->getLang('figure')." ".$refNumber." </a>";
                         $renderer->doc .= $str;
 
                     } else {
-                        $warning = "$data<sup style=\"color:#FF0000;\">".$this->getLang('error_imgrefbeforeimgcaption')."</sup>";
+                        $warning = cleanID($data)."<sup style=\"color:#FF0000;\">".$this->getLang('error_imgrefbeforeimgcaption')."</sup>";
                         $renderer->doc .= $warning;
                     }
-                    break;
-
-                // data is mostly empty!!!
-                case 'data' :
-                    $renderer->doc .= $data;
                     break;
             }
 
@@ -107,10 +102,6 @@ class syntax_plugin_imagereference_imgref extends DokuWiki_Syntax_Plugin {
             switch($case) {
                 case 'imgref' :
                     $renderer->doc .= "\\ref{".$data."}";
-                    break;
-
-                case 'data' :
-                    $renderer->doc .= trim($data);
                     break;
             }
 


### PR DESCRIPTION
used ptype is normal, with imgcaption as spans..
alignments are similar to alignments of `{{images}}`
added center alignment as block
javascript copies alignment from images to imgcaption, when no alignment was given for the imgcaption
rewritten javascript with jQuery
simplified parse and render functions
added dutch translation
removed getInfo() functions

look at the commits to see the changes, the code reformatting touches almost everything.
